### PR TITLE
Move black to dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,5 +1,5 @@
 [[package]]
-category = "main"
+category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
 optional = false
@@ -23,7 +23,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.0"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
@@ -31,7 +31,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "19.1.0"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "The uncompromising code formatter."
 name = "black"
 optional = false
@@ -61,7 +61,7 @@ python-versions = "*"
 version = "3.0.4"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
@@ -275,7 +275,7 @@ python-versions = ">=3.6"
 version = "0.12.0"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
@@ -307,7 +307,7 @@ python-versions = ">=2.7"
 version = "0.5.1"
 
 [metadata]
-content-hash = "b59fc99a9dc8c0de036b83ea0c3931531021f5bccb89765e9bc900d93d954791"
+content-hash = "3fb3c834dddb3ac5b20588d426e22095c4fbbeb52e67a5f17e96b71dd1b64ae0"
 python-versions = "^3.6"
 
 [metadata.hashes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "content_size_limit_asgi"
-version = "0.1.3"
+version = "0.1.4"
 description = "An ASGI3 middleware to implement maximum content size limits (mostly useful for HTTP uploads)"
 authors = ["Steinn Eldjárn Sigurðarson <steinnes@gmail.com>"]
 license = "MIT"
@@ -9,7 +9,6 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.6"
 starlette = "^0.12.0"
-black = {version = "^18.3-alpha.0", allows-prereleases = true}
 [tool.poetry.dev-dependencies]
 pytest = "^4.6"
 pytest-cov = "^2.7"
@@ -17,7 +16,7 @@ flake8 = "^3.7"
 asynctest = "^0.13.0"
 pytest-asyncio = "^0.10.0"
 requests = "^2.22"
-
+black = {version = "^18.3-alpha.0", allows-prereleases = true}
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Accidentally added black as a normal dependency.  It being a pre-release
this is hazardous.